### PR TITLE
Added explicit libraries for Wayland include locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,44 @@
 # DWService - Agent
+
 This is [DWService](https://www.dwservice.net) agent for operative systems Linux, Mac and Windows.
 The code is written in python2 and several libraries are written c++. 
 
 ## Start the agent
+
 If you prefer you can start the agent from the sources but you keep in mind in this mode the agent does not update automatically, so you need to update sources manually every time. Before to start the agent you need to:
 - Install python3
 - Install g++/make (if Windows download [Mingw-w64](https://mingw-w64.org) version [64bit](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-win32/sjlj/) or [32bit](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/8.1.0/threads-win32/sjlj/))
+- To compile Wayland support on Linux, install libraries: `libpipewire-0.3-dev`, `libdbus-1-3`, and `libdbus-1-dev`
 - Download agent source code ([zip](https://github.com/dwservice/agent/archive/master.zip) or git clone)
 - Execute these commands from agent/make:
 
-```
-python3 compile_all.py (compile all c++ libraries)
-python3 create_config.py (create config.json in agent/core path)
-```
-
-now you are ready to start the agent by execute this command from agent/core:
-
-```
-python3 agent.py
+```bash
+python3 ./compile_all.py; # Compile all c++ libraries.
+python3 ./create_config.py; # Create Agent config.json in agent/core path.
 ```
 
+Now you are ready to start the agent by execute this command from agent/core:
+
+```
+python3 ./agent.py;
+```
+
+If the agent still tries setting up a Xorg session on client connect, with Wayland active and even environment `XDG_SESSION_TYPE=wayland` set, try forcing Wayland in the agent configuration:
+```diff
+    "enabled": true,
+    "debug_mode": true,
++     "desktop": {
++         "force_capturescreenlib": "wayland"
++     }
+```
 
 ## Setup the agent for development
+
 Thanks [Eclipse](https://www.eclipse.org) + [Pydev](https://marketplace.eclipse.org/content/pydev-python-ide-eclipse) and [CDT](https://marketplace.eclipse.org/content/complete-eclipse-cc-ide) you can develop the agent with only one IDE from your prefer operative system. You also need of python3 and g++/make (if Windows download [Mingw-w64](https://mingw-w64.org) version [64bit](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-win32/sjlj/) or [32bit](https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/8.1.0/threads-win32/sjlj/)) installed on your system. After configuring the IDE and importing the source code, you need to execute same scripts of **"Start the agent"** section.
 
 You can read the [guide on the wiki](https://github.com/dwservice/agent/wiki/Setup-the-agent-for-development) to learn how to setup the agent for development.
 
 ## License Agreement
+
 This software is free and open source. 
 It consists of one core component released under the MPLv2 license, and several libraries and components defined "app" that could be governed by different licenses. you can read the "LICENSE" file in each folder.

--- a/make/compile_lib_screencapture_wayland.py
+++ b/make/compile_lib_screencapture_wayland.py
@@ -16,10 +16,10 @@ class Compile(compile_generic.Compile):
         if osn=="linux":
             conf={}
             conf["outname"]="dwagscreencapturewayland.so" 
-            conf["cpp_include_paths"]=["/usr/include/dbus-1.0","/usr/lib/dbus-1.0/include","/usr/include/pipewire-0.3","/usr/include/spa-0.2"] 
+            conf["cpp_include_paths"]=["/usr/include/dbus-1.0","/usr/lib/dbus-1.0/include","/usr/lib/x86_64-linux-gnu/dbus-1.0/include","/usr/include/pipewire-0.3","/usr/include/spa-0.2"] 
             #conf["cpp_library_paths"]=""
             conf["libraries"]=["dbus-1", "pipewire-0.3"]
-            conf["cpp_compiler_flags"]="-DOS_WAYLAND"
+            conf["cpp_compiler_flags"]="-DOS_WAYLAND -Wno-unused-result"
         return conf
     
 


### PR DESCRIPTION
Dear Developers and Artists,

Thank you for the marvel you do...

With the recent Agent compilation attempts on latest distribution Kubuntu 25.10, the G++ didn't find the installed DBus file `dbus-arch-deps.h`, for libraries, actually located in:
```
$ tree -- /usr/lib/x86_64-linux-gnu/dbus-1.0/include;
/usr/lib/x86_64-linux-gnu/dbus-1.0/include
└── dbus
    └── dbus-arch-deps.h

2 directories, 1 file
```

The `no-unused-result` was for the following error that appeared on compilation:
```
Error:
/opt/apps/vendor/dwservice/agent/lib_screencapture/src/wayland/screencapturenativewayland.cpp: In function ‘void dbusSetClipboard(DBusMessage*)’:
/opt/apps/vendor/dwservice/agent/lib_screencapture/src/wayland/screencapturenativewayland.cpp:424:30: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
  424 |                         write(fd, dbusclipboard.data, dbusclipboard.sizedata);
      |                         ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I am not sure if that is the most appropriate solution, but please consider checking it out, and if anything please do request additional details I'll try to respond with!

Best and kind regards ✨ 